### PR TITLE
Add project-directory option

### DIFF
--- a/src/Task/Base.php
+++ b/src/Task/Base.php
@@ -96,6 +96,20 @@ abstract class Base extends BaseTask implements CommandInterface
 
         return $this;
     }
+    
+    
+    /**
+     * Specify an alternate project directory.
+     *
+     * @param string
+     *   A directory path for the base of the project.
+     */
+    public function projectDirectory($dir)
+    {
+        $this->execOption('project-directory', $dir);
+
+        return $this;
+    }
 
     /**
      * Daemon socket to connect to.


### PR DESCRIPTION
Docker compose provides a command-line option to provide a dir other than the yml file's location for the project root.